### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/website/content/download.html
+++ b/website/content/download.html
@@ -39,7 +39,7 @@ program which can be used to install PyEnchant.
 <li><a href="http://pypi.python.org/packages/any/p/pyenchant/pyenchant-1.6.6.win32.exe">pyenchant-1.6.6.win32.exe</a></li>
 </ul>
 
-<p>There is also a <a href="http://wheel.readthedocs.org/en/latest/">wheel</a> available for users who prefer them, which can be installed using <a href="http://pip.readthedocs.org/en/latest/">pip</a>:</p>
+<p>There is also a <a href="https://wheel.readthedocs.io/en/latest/">wheel</a> available for users who prefer them, which can be installed using <a href="https://pip.readthedocs.io/en/latest/">pip</a>:</p>
 <ul>
 <li><a href="https://pypi.python.org/packages/py2.py3.cp27.cp26.cp32.cp33.cp34.pp27/p/pyenchant/pyenchant-1.6.6-py2.py3.cp27.cp26.cp32.cp33.cp34.pp27-none-win32.whl">pyenchant-1.6.6-py2.py3.cp27.cp26.cp32.cp33.cp34.pp27-none-win32.whl</a></li>
 </ul>
@@ -62,7 +62,7 @@ Windows users can also follow the instructions above to build from source.
 
 <h3>Mac OS X Users</h3>
 
-<p>For convenience, Mac OS X users are provided with a pre-built binary <a href="">wheel"</a> which can be installed using <a href="http://pip.readthedocs.org/en/latest/">pip</a>:</p>
+<p>For convenience, Mac OS X users are provided with a pre-built binary <a href="">wheel"</a> which can be installed using <a href="https://pip.readthedocs.io/en/latest/">pip</a>:</p>
 <ul>
 <li><a href="https://pypi.python.org/packages/py2.py3.cp27.cp26.cp32.cp33.cp34.pp27/p/pyenchant/pyenchant-1.6.6-py2.py3.cp27.cp26.cp32.cp33.cp34.pp27-none-macosx_10_6_intel.macosx_10_9_intel.whl">pyenchant-1.6.6-py2.py3.cp27.cp26.cp32.cp33.cp34.pp27-none-macosx_10_6_intel.macosx_10_9_intel.whl</a></li>
 </ul>

--- a/website/content/tutorial.rst
+++ b/website/content/tutorial.rst
@@ -17,7 +17,7 @@ Installing the Package
 
 Your operating system distributor may provide PyEnchant via their own packaging system - please check there first.
 
-If a package is not provided by your operating system distributor, you will need to install one of the pre-build binary distributions or build the package from source.  The easiest way to install PyEnchant is via `pip <http://pip.readthedocs.org/en/latest/>`_ which will locate and install the appropriate pre-built distribution for your platform.  Simply::
+If a package is not provided by your operating system distributor, you will need to install one of the pre-build binary distributions or build the package from source.  The easiest way to install PyEnchant is via `pip <https://pip.readthedocs.io/en/latest/>`_ which will locate and install the appropriate pre-built distribution for your platform.  Simply::
 
     pip install pyenchant
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
