### PR TITLE
support typographic apostrophes #93

### DIFF
--- a/enchant/tokenize/en.py
+++ b/enchant/tokenize/en.py
@@ -62,7 +62,7 @@ class tokenize(enchant.tokenize.tokenize):
 
     _DOC_ERRORS = ["pos","pos"]
     
-    def __init__(self,text,valid_chars=("'",)):
+    def __init__(self,text,valid_chars=("'", u"\u2019")):
         self._valid_chars = valid_chars
         self._text = text
         self._offset = 0

--- a/enchant/tokenize/tests.py
+++ b/enchant/tokenize/tests.py
@@ -313,3 +313,10 @@ of words. Also need to "test" the handling of 'quoted' words."""
         for (itmO,itmV) in zip(outputT,tokenize_en(inputT)):
             self.assertEqual(itmO,itmV)
 
+    def test_typographic_apostrophe_en(self):
+        """"Typographic apostrophes shouldn't be word separators in English."""
+        from enchant.tokenize import en
+        tknzr = wrap_tokenizer(basic_tokenize, en.tokenize)
+        input = u"They\u2019ve"
+        output = [(u"They\u2019ve", 0)]
+        self.assertEqual(output, [i for i in tknzr(input)])


### PR DESCRIPTION
I implemented a fix that might be suboptimal.
I tried adding the typographic apostrophe to the `valid_chars` of the English tokenizer's initialization function, but this didn't lead to the desired results. Afterwards, the spell checker didn't recognize any words with a typographic apostrophe.