### PR TITLE
Re-enable support for typographic apostrophe.

### DIFF
--- a/enchant/tests.py
+++ b/enchant/tests.py
@@ -187,7 +187,22 @@ class TestDict(unittest.TestCase):
         self.assertFalse(self.dict.check("helo"))
         self.assertFalse(self.dict.check("testt"))
         self.assertRaises(ValueError, self.dict.check, "")
-        
+
+    def test_check_apostrophes(self):
+        """Test that check() works on some common words."""
+        self.assertTrue(self.dict.check("isn't"))
+        self.assertTrue(self.dict.check("They're"))
+        self.assertTrue(self.dict.check("Python's"))
+        self.assertFalse(self.dict.check("is't"))
+        self.assertFalse(self.dict.check("They*re"))
+        self.assertFalse(self.dict.check("Python|s"))
+        self.assertTrue(self.dict.check(u"isn\u2019t"))
+        self.assertTrue(self.dict.check(u"They\u2019re"))
+        self.assertTrue(self.dict.check(u"Python\u2019s"))
+        self.assertFalse(self.dict.check(u"is\u2019t"))
+        self.assertFalse(self.dict.check(u"They\u2017re"))
+        self.assertFalse(self.dict.check(u"Python\u2020s"))
+
     def test_broker(self):
         """Test that the dict's broker is set correctly."""
         self.assertTrue(self.dict._broker is enchant._broker)

--- a/enchant/tokenize/en.py
+++ b/enchant/tokenize/en.py
@@ -90,11 +90,8 @@ class tokenize(enchant.tokenize.tokenize):
     def _initialize_for_unicode(self):
         self._consume_alpha = self._consume_alpha_u
         if self._valid_chars is None:
-            # XXX TODO: this doesn't seem to work correctly with the
-            # MySpell provider, disabling for now.
             # Allow unicode typographic apostrophe
-            #self._valid_chars = (u"'",u"\u2019")
-            self._valid_chars = (u"'",)
+            self._valid_chars = (u"'",u"\u2019")
     
     def _consume_alpha_b(self,text,offset):
         """Consume an alphabetic character from the given bytestring.

--- a/enchant/tokenize/tests.py
+++ b/enchant/tokenize/tests.py
@@ -313,16 +313,14 @@ of words. Also need to "test" the handling of 'quoted' words."""
         for (itmO,itmV) in zip(outputT,tokenize_en(inputT)):
             self.assertEqual(itmO,itmV)
 
-    # XXX TODO: the myspell provider doesn't correctly interpret
-    # typographic apostrophe on OSX, disabling for now.
-    #def test_typographic_apostrophe_en(self):
-    #    """"Typographic apostrophes shouldn't be word separators in English."""
-    #    from enchant.tokenize import en
-    #    tknzr = wrap_tokenizer(basic_tokenize, en.tokenize)
-    #    input = u"They\u2019re here"
-    #    output = [(u"They\u2019re", 0), (u"here", 8)]
-    #    self.assertEqual(output, [i for i in tknzr(input)])
-    #    # Typographic apostrophe is only support for unicode inputs.
-    #    if str is not unicode:
-    #        output = [("They", 0), ("re", 7), ("here", 10)]
-    #        self.assertEqual(output, [i for i in tknzr(input.encode('utf8'))])
+    def test_typographic_apostrophe_en(self):
+        """"Typographic apostrophes shouldn't be word separators in English."""
+        from enchant.tokenize import en
+        tknzr = wrap_tokenizer(basic_tokenize, en.tokenize)
+        input = u"They\u2019re here"
+        output = [(u"They\u2019re", 0), (u"here", 8)]
+        self.assertEqual(output, [i for i in tknzr(input)])
+        # Typographic apostrophe is only support for unicode inputs.
+        if str is not unicode:
+            output = [("They", 0), ("re", 7), ("here", 10)]
+            self.assertEqual(output, [i for i in tknzr(input.encode('utf8'))])


### PR DESCRIPTION
This includes some additional tests to ensure that it is correctly handled by the underlying spellcheck engine.