### PR TITLE
Auto-detect enchant2

### DIFF
--- a/enchant/_enchant.py
+++ b/enchant/_enchant.py
@@ -72,6 +72,7 @@ def _e_path_possibilities():
         yield "libenchant.so"
     # See if ctypes can find the library for us, under various names.
     yield find_library("enchant")
+    yield find_library("enchant-2")
     yield find_library("libenchant")
     yield find_library("libenchant-1")
     # Special-case handling for enchant installed by macports.


### PR DESCRIPTION
After support for enchant2 is already merged, the only thing missing is to detect the library :)

I am aware that you are no longer maintaining this, so feel no pressure to merge or even release this. But having this pull request here might help people to find out why this isn't running on Arch Linux currently and can discover the workaround of installing this fork:
``pip install git+https://github.com/raphaelm/pyenchant.git@patch-1#egg=pyenchant``