### PR TITLE
Fix pyenchant install on Arch Linux

### DIFF
--- a/enchant/_enchant.py
+++ b/enchant/_enchant.py
@@ -71,6 +71,7 @@ def _e_path_possibilities():
         yield "libenchant.so.1.6.0"
         yield "libenchant.so.1"
         yield "libenchant.so"
+        yield "libenchant-2.so"
     # See if ctypes can find the library for us, under various names.
     yield find_library("enchant")
     yield find_library("enchant-2")


### PR DESCRIPTION
When installing pyenchant from pip on Arch Linux (or Manjaro) the follow error occurs:

```
 pip install pyenchant
Collecting pyenchant
  Using cached https://files.pythonhosted.org/packages/9e/54/04d88a59efa33fefb88133ceb638cdf754319030c28aadc5a379d82140ed/pyenchant-2.0.0.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /opt/python/pyenv/versions/3.8.0/bin/python3.8 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-ork84sag/pyenchant/setup.py'"'"'; __file__='"'"'/tmp/pip-install-ork84sag/pyenchant/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-ork84sag/pyenchant/pip-egg-info
         cwd: /tmp/pip-install-ork84sag/pyenchant/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-ork84sag/pyenchant/setup.py", line 212, in <module>
        import enchant
      File "/tmp/pip-install-ork84sag/pyenchant/enchant/__init__.py", line 92, in <module>
        from enchant import _enchant as _e
      File "/tmp/pip-install-ork84sag/pyenchant/enchant/_enchant.py", line 145, in <module>
        raise ImportError(msg)
    ImportError: The 'enchant' C library was not found. Please install it via your OS package manager, or use a pre-built binary wheel from PyPI.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

The problem occurs because Arch Linux distributes enchant-2:

```
pacman -Qi enchant
Name            : enchant
Version         : 2.2.7-1
Description     : A wrapper library for generic spell checking
Architecture    : x86_64
URL             : https://abiword.github.io/enchant/
Licenses        : LGPL
Groups          : None
Provides        : None
Depends On      : aspell  hunspell  hspell  libvoikko  glib2
Optional Deps   : None
Required By     : gspell  gtkspell  gtkspell3  python-pyenchant  webkit2gtk
Optional For    : None
Conflicts With  : None
Replaces        : None
Installed Size  : 167,00 KiB
Packager        : Antonio Rojas <arojas@archlinux.org>
Build Date      : qui 26 set 2019 03:06:28 -03
Install Date    : seg 14 out 2019 13:36:36 -03
Install Reason  : Installed as a dependency for another package
Install Script  : No
Validated By    : Signature
```

```
ls /usr/local/lib/
enchant-2  libenchant-2.a  libenchant-2.la  libenchant-2.so  libenchant-2.so.2  libenchant-2.so.2.2.7  pkgconfig
```

So expected library name should be **enchant-2**.